### PR TITLE
Feature: Leader-Unit Grouping and Display (Issue #3)

### DIFF
--- a/cheat_sheet_generator.py
+++ b/cheat_sheet_generator.py
@@ -738,14 +738,7 @@ class CheatSheetGenerator:
         if cheat_sheet.get('unit_attachments'):
             grouped = self._group_units_by_attachments(cheat_sheet)
 
-            # Unattached characters first
-            if grouped['unattached_characters']:
-                lines.append("## Characters")
-                lines.append("")
-                for char in grouped['unattached_characters']:
-                    self._format_unit_markdown(char, lines)
-
-            # Led units (leader + unit pairs)
+            # Led units first (leader + unit pairs, warlord-led first)
             if grouped['attached_groups']:
                 lines.append("## Led Units")
                 lines.append("")
@@ -757,14 +750,21 @@ class CheatSheetGenerator:
                     lines.append("")
                     self._format_unit_markdown(group['unit'], lines)
 
-            # Unled units
+            # Unattached characters second
+            if grouped['unattached_characters']:
+                lines.append("## Characters")
+                lines.append("")
+                for char in grouped['unattached_characters']:
+                    self._format_unit_markdown(char, lines)
+
+            # Unled units third
             if grouped['unled_units']:
                 lines.append("## Unled Units")
                 lines.append("")
                 for unit in grouped['unled_units']:
                     self._format_unit_markdown(unit, lines)
 
-            # Transports
+            # Transports last
             if grouped['transports']:
                 lines.append("## Transports")
                 lines.append("")
@@ -1339,14 +1339,7 @@ class CheatSheetGenerator:
         if cheat_sheet.get('unit_attachments'):
             grouped = self._group_units_by_attachments(cheat_sheet)
 
-            # Unattached characters first
-            if grouped['unattached_characters']:
-                html_parts.append('        <h2 class="section-title">Characters</h2>')
-                char_page_breaks = self._assign_page_groups(grouped['unattached_characters'])
-                for i, char in enumerate(grouped['unattached_characters']):
-                    html_parts.append(self._format_unit_html(char, is_character=True, page_break_class=char_page_breaks[i]))
-
-            # Led units (leader + unit pairs) - add CSS for grouping
+            # Led units first (leader + unit pairs, warlord-led first)
             if grouped['attached_groups']:
                 html_parts.append('        <h2 class="section-title">Led Units</h2>')
                 for group in grouped['attached_groups']:
@@ -1358,14 +1351,21 @@ class CheatSheetGenerator:
                     html_parts.append('            </div>')
                     html_parts.append('        </div>')
 
-            # Unled units
+            # Unattached characters second
+            if grouped['unattached_characters']:
+                html_parts.append('        <h2 class="section-title">Characters</h2>')
+                char_page_breaks = self._assign_page_groups(grouped['unattached_characters'])
+                for i, char in enumerate(grouped['unattached_characters']):
+                    html_parts.append(self._format_unit_html(char, is_character=True, page_break_class=char_page_breaks[i]))
+
+            # Unled units third
             if grouped['unled_units']:
                 html_parts.append('        <h2 class="section-title">Unled Units</h2>')
                 unit_page_breaks = self._assign_page_groups(grouped['unled_units'])
                 for i, unit in enumerate(grouped['unled_units']):
                     html_parts.append(self._format_unit_html(unit, is_character=False, page_break_class=unit_page_breaks[i]))
 
-            # Transports
+            # Transports last
             if grouped['transports']:
                 html_parts.append('        <h2 class="section-title">Transports</h2>')
                 transport_page_breaks = self._assign_page_groups(grouped['transports'])

--- a/static/style.css
+++ b/static/style.css
@@ -323,6 +323,90 @@ footer a:hover {
     text-decoration: underline;
 }
 
+/* Leader Selection UI */
+.leader-selection-container {
+    background: var(--card-bg);
+    border-radius: 15px;
+    padding: 40px;
+    margin: 30px 0;
+}
+
+.leader-selection-container h2 {
+    color: var(--primary-color);
+    margin-bottom: 10px;
+    font-size: 2rem;
+    text-align: center;
+}
+
+.leader-selection-container > p {
+    text-align: center;
+    color: var(--text-secondary);
+    margin-bottom: 30px;
+    font-size: 1.1rem;
+}
+
+.leader-cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 20px;
+    margin: 30px 0;
+}
+
+.leader-card {
+    background: var(--bg-color);
+    border: 2px solid var(--border-color);
+    border-radius: 10px;
+    padding: 20px;
+    transition: all 0.3s;
+}
+
+.leader-card:hover {
+    border-color: var(--primary-color);
+    box-shadow: 0 5px 15px rgba(139, 0, 0, 0.3);
+}
+
+.leader-card h3 {
+    color: var(--primary-color);
+    margin-bottom: 15px;
+    font-size: 1.3rem;
+    border-bottom: 2px solid var(--border-color);
+    padding-bottom: 10px;
+}
+
+.leader-card label {
+    display: block;
+    margin-bottom: 8px;
+    font-weight: 600;
+    color: var(--text-secondary);
+}
+
+.leader-select {
+    width: 100%;
+    padding: 10px;
+    background: var(--card-bg);
+    border: 2px solid var(--border-color);
+    border-radius: 6px;
+    color: var(--text-primary);
+    font-size: 1rem;
+    cursor: pointer;
+    transition: border-color 0.3s;
+}
+
+.leader-select:hover {
+    border-color: var(--primary-color);
+}
+
+.leader-select:focus {
+    outline: none;
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 3px rgba(139, 0, 0, 0.2);
+}
+
+.leader-select option:disabled {
+    color: #666;
+    font-style: italic;
+}
+
 /* Responsive Design */
 @media (max-width: 768px) {
     header h1 {


### PR DESCRIPTION
## Summary
Implements leader-unit grouping functionality for cheat sheets (Issue #3) with enhanced display and sorting capabilities.

## Changes

### Backend Implementation
1. **Leader Detection and Grouping** (`cheat_sheet_generator.py`)
   - New `_group_units_by_attachments()` method categorizes units into:
     * Unattached characters
     * Led units (leader-unit pairs)
     * Unled units
     * Dedicated transports/vehicles
   - Sorts warlord-led groups to appear first
   - Handles duplicate unit names with `#N` suffix support

2. **Linked Catalogue Support** (`catalogue_manager.py`)
   - Added `FACTION_LINKED_CATALOGUES` mapping for chapter dependencies
   - Rewrote `download_and_parse_catalogue()` to:
     * Download main + linked catalogues together
     * Parse with full linked catalogue support
     * Cache complete dataset to YAML
   - Fixes weapon display for Space Marines chapters (Space Wolves, Blood Angels, etc.)

3. **Weapon Name Matching** (`cheat_sheet_generator.py`)
   - Enhanced `_normalize_weapon_name()` to handle spacing inconsistencies
   - Improved `_weapon_matches()` with 4 fuzzy matching strategies
   - Handles catalogue vs army list name differences (e.g., "great axe" vs "greataxe")

### Frontend Implementation
1. **Leader Selection UI** (`app.py`, `script.js`, `style.css`)
   - New multi-step workflow: Upload → Select Leaders → Download
   - Dynamic leader-unit pairing interface
   - Duplicate unit support with instance counters
   - Real-time validation and feedback

2. **Display Enhancements** (`cheat_sheet_generator.py`)
   - Leader groups displayed with visual grouping
   - Output order: warlord-led → other led → unattached → unled → transports
   - Multi-model units show Pack Leader/Sergeant weapons separately
   - Improved page break handling for printing

## Fixes
- ✅ Weapon display regression: All weapons now show correctly (ranged + melee)
- ✅ Pack Leader weapons: Sergeant/Pack Leader weapons display properly
- ✅ Output ordering: Warlord-led units appear first as intended
- ✅ Linked catalogues: Common Space Marines weapons now load correctly

## Testing
Tested with complete Space Wolves army including:
- Multiple characters (Logan Grimnar as warlord, Wolf Guard Battle Leader, Arjac Rockfist)
- Multi-model units (Blood Claws, Grey Hunters, Wolf Guard Terminators)
- Leader attachments with proper sorting
- Dedicated transports (Rhino)
- All weapon profiles display correctly

## Test Files Added
- `test_complete_army.py` - Comprehensive test with all scenarios
- `test_weapons.py` - Grey Hunters weapon display verification
- `test_weapons_debug.py` - Weapon matching debug script
- `test_terminators.py` - Wolf Guard Terminators weapon test
- `test_terminators_debug.py` - Pack Leader weapon matching debug

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>